### PR TITLE
Add all supported models

### DIFF
--- a/lib/download_model.dart
+++ b/lib/download_model.dart
@@ -15,21 +15,41 @@ enum WhisperModel {
   // no model
   none(""),
 
-  /// tiny model for all languages
+  /// tiny models for all languages
   tiny("tiny"),
+  tinyQ5("tiny-q5_1"),
+  /// tiny models for English only
+  tinyEn("tiny.en"),
+  tinyEnQ5("tiny.en-q5_1"),
+  tinyEnQ8("tiny.en-q8_0"),
 
-  /// base model for all languages
+  /// base models for all languages
   base("base"),
+  baseQ5("base-q5_1"),
+  /// base models for English only
+  baseEn("base.en"),
+  baseEnQ5("base.en-q5_1"),
 
-  /// small model for all languages
+  /// small models for all languages
   small("small"),
+  smallQ5("small-q5_1"),
+  /// small models for English only
+  smallEn("small.en"),
+  smallEnQ5("small.en-q5_1"),
 
-  /// medium model for all languages
+  /// medium models for all languages
   medium("medium"),
+  mediumQ5("medium-q5_0"),
+  /// medium models for English only
+  mediumEn("medium.en"),
+  mediumEnQ5("medium.en-q5_0"),
 
-  /// large model for all languages
+  /// large models for all languages
   largeV1("large-v1"),
-  largeV2("large-v2");
+  largeV2("large-v2"),
+  largeV2Q5("large-v2-q5_0"),
+  largeV3("large-v3"),
+  largeV3Q5("large-v3-q5_0");
 
   const WhisperModel(this.modelName);
 


### PR DESCRIPTION
Hi, thanks for the project! I tested it on Android and it actually worked.

**Changed** : 
1. Added all supported models from [ggerganov/whisper.cpp](https://huggingface.co/ggerganov/whisper.cpp/tree/main), including `.en` (English only) and quantization models.

Here's my test result with the `base` models for [jfk.wav](https://github.com/xuegao-tzx/whisper_flutter_new/blob/main/example/assets/jfk.wav):
- Device

| Device Name      | RAM Capacity | CPU Clock |
|------------------|--------------|-----------|
| Android Galaxy Quantum 3 | 8 GB    | 2400 MHz  |

- Result

| `base`    | `base-q5_1` | `base.en` | `base.en-q5_1` |
|---------|-----------|---------|--------------|
| 17.319 s| 16.235 s  | 15.552 s| 15.016 s     |

It only took 3.992 s from the official demo, so it seems this doesn't help #1. 
But I think it would be good to support all models.
